### PR TITLE
Fix thread code for platforms that don't support it

### DIFF
--- a/hxbolts/Task.hx
+++ b/hxbolts/Task.hx
@@ -306,7 +306,7 @@ class Task<TResult> {
         }
 
         var tcs = new TaskCompletionSource<TResult>();
-		trace(callable);
+
         executor.execute(function() : Void {
             try {
                 tcs.setResult(callable());

--- a/hxbolts/Task.hx
+++ b/hxbolts/Task.hx
@@ -27,7 +27,6 @@ import hxbolts.executors.TaskExecutor;
 #end
 
 class Task<TResult> {
-    public static var IMMEDIATE_EXECUTOR(default, null) : TaskExecutor = new ImmediateTaskExecutor();
 
     private var _isCompleted : Bool;
     private var _isFaulted : Bool;
@@ -100,7 +99,7 @@ class Task<TResult> {
         ?executor : TaskExecutor
     ) : Task<TContinuationResult> {
         if (executor == null) {
-            executor = IMMEDIATE_EXECUTOR;
+            executor = TaskExt.IMMEDIATE_EXECUTOR;
         }
 
         var tcs = new TaskCompletionSource<TContinuationResult>();
@@ -138,7 +137,7 @@ class Task<TResult> {
         ?executor : TaskExecutor
     ) : Task<TContinuationResult> {
         if (executor == null) {
-            executor = IMMEDIATE_EXECUTOR;
+            executor = TaskExt.IMMEDIATE_EXECUTOR;
         }
 
         var tcs = new TaskCompletionSource<TContinuationResult>();
@@ -303,11 +302,11 @@ class Task<TResult> {
 
     public static function call<TResult>(callable : Void -> Null<TResult>, ?executor : TaskExecutor) : Task<TResult> {
         if (executor == null) {
-            executor = IMMEDIATE_EXECUTOR;
+            executor = TaskExt.IMMEDIATE_EXECUTOR;
         }
 
         var tcs = new TaskCompletionSource<TResult>();
-
+		trace(callable);
         executor.execute(function() : Void {
             try {
                 tcs.setResult(callable());

--- a/hxbolts/TaskExt.hx
+++ b/hxbolts/TaskExt.hx
@@ -8,6 +8,9 @@
  */
 package hxbolts;
 
+import hxbolts.executors.ImmediateTaskExecutor;
+import hxbolts.executors.TaskExecutor;
+
 #if (flash || nme || openfl || lime)
     import hxbolts.executors.UiThreadTaskExecutor;
 #end
@@ -17,6 +20,8 @@ package hxbolts;
 #end
 
 class TaskExt {
+	public static var IMMEDIATE_EXECUTOR(default, null) : TaskExecutor = new ImmediateTaskExecutor();
+	
     #if (flash || nme || openfl || lime)
         private static var _UI_EXECUTOR : UiThreadTaskExecutor = null;
         public static var UI_EXECUTOR(get, null) : UiThreadTaskExecutor;
@@ -43,5 +48,7 @@ class TaskExt {
 
             return _BACKGROUND_EXECUTOR;
         }
-    #end
+    #else
+		public static var BACKGROUND_EXECUTOR = IMMEDIATE_EXECUTOR;
+	#end
 }

--- a/hxbolts/executors/CurrentThreadTaskExecutor.hx
+++ b/hxbolts/executors/CurrentThreadTaskExecutor.hx
@@ -17,29 +17,41 @@ package hxbolts.executors;
 #end
 
 class CurrentThreadTaskExecutor implements TaskExecutor {
+	#if (cpp || neko || java)
     private var runnableQueueMutex : Mutex = new Mutex();
+	#end
     private var runnableQueue : List<Void -> Void> = new List<Void -> Void>();
 
     public function new() : Void {
     }
 
     public function execute(runnable : Void -> Void) : Void {
+		#if (cpp || neko || java)
         runnableQueueMutex.acquire();
+		#end
         runnableQueue.add(runnable);
+		#if (cpp || neko || java)
         runnableQueueMutex.release();
+		#end
     }
 
     public function tick() : Void {
+		#if (cpp || neko || java)
         runnableQueueMutex.acquire();
-
+		#end
+		
         if (runnableQueue.isEmpty()) {
+			#if (cpp || neko || java)
             runnableQueueMutex.release();
+			#end
             return;
         }
 
         var queue = Lambda.list(runnableQueue);
         runnableQueue.clear();
+		#if (cpp || neko || java)
         runnableQueueMutex.release();
+		#end
 
         var runnable : Void -> Void;
 

--- a/hxbolts/executors/UiThreadTaskExecutor.hx
+++ b/hxbolts/executors/UiThreadTaskExecutor.hx
@@ -8,7 +8,7 @@
  */
 package hxbolts.executors;
 
-#if (flash || nme || openfl)
+#if (flash && (nme || openfl))
     import openfl.Lib;
     import openfl.events.Event;
 #elseif lime
@@ -25,7 +25,7 @@ class UiThreadTaskExecutor extends CurrentThreadTaskExecutor {
     public function new() : Void {
         super();
 
-        #if (flash || nme || openfl)
+        #if (flash && (nme || openfl))
             Lib.current.stage.addEventListener(Event.ENTER_FRAME, onNextFrame);
         #elseif lime
             Application.current.onUpdate.add(onNextFrame);
@@ -40,7 +40,7 @@ class UiThreadTaskExecutor extends CurrentThreadTaskExecutor {
     }
 
     override public function shutdown() : Void {
-        #if (flash || nme || openfl)
+        #if (flash && (nme || openfl))
             Lib.current.stage.removeEventListener(Event.ENTER_FRAME, onNextFrame);
         #elseif lime
             Application.current.onUpdate.remove(onNextFrame);


### PR DESCRIPTION
Fix build for non-openfl projects.

This move IMMEDIATE_EXECUTOR from Task to TaskExt and set BACKGROUND_EXECUTOR = IMMEDIATE_EXECUTOR on platform that don't support threads to avoid the user having to wrap code for those cases.
